### PR TITLE
Rename checkpoints from temporary files instead of overwriting

### DIFF
--- a/crates/psqs/src/queue/drain/mod.rs
+++ b/crates/psqs/src/queue/drain/mod.rs
@@ -346,7 +346,7 @@ pub(crate) trait Drain {
         Self::Item: Serialize,
     {
         let c = Checkpoint { dst, jobs };
-        eprintln!("writing checkpoint to {checkpoint}");
+        log::info!("writing checkpoint to {checkpoint}");
         let f = std::fs::File::create(checkpoint).unwrap();
         serde_json::to_writer_pretty(f, &c).unwrap();
     }


### PR DESCRIPTION
Closes https://github.com/ntBre/pbqff/issues/341 and also improves logging and avoids unwrapping on any checkpointing failures.