### PR TITLE
Delete unused file copy in resubmission

### DIFF
--- a/crates/psqs/src/queue/drain/resub.rs
+++ b/crates/psqs/src/queue/drain/resub.rs
@@ -80,19 +80,6 @@ impl<
             let path = Path::new(&filename);
             let dir = path.parent().unwrap().to_str().unwrap();
             let base = path.file_stem().unwrap().to_str().unwrap();
-            {
-                let ext = path.extension().unwrap().to_str().unwrap();
-                let inp_file = format!("{dir}/{base}_redo.{ext}");
-                match std::fs::copy(&filename, &inp_file) {
-                    Ok(_) => (),
-                    Err(e) => {
-                        panic!(
-                            "failed to copy {} to {} with `{}`",
-                            &filename, inp_file, e
-                        )
-                    }
-                };
-            }
             // nothing but the copy needs the name with extension
             let inp_name = format!("{dir}/{base}_redo");
             job.program.set_filename(&inp_name);


### PR DESCRIPTION
Closes #340. As mentioned in the issue, there is some nuance here around whether it's more useful to perform the copy and allow the user to modify the initial file or rewrite the file from memory. I'm still not totally decided on that issue[^1], but I think it's still worth deleting this unused code to make it clear where the resubmitted files are coming from.

[^1]: I am leaning toward preserving the current behavior, though, in order to maintain the accuracy of the checkpoints. That's another reason for the simple approach in this PR. It will be a bigger, separate feature to add full support for modifying individual file templates at runtime.