### PR TITLE
Fix for clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,15 +115,15 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -138,9 +138,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "cast"
@@ -229,9 +229,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -320,9 +320,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -355,15 +355,15 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -377,21 +377,21 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
+ "r-efi",
  "wasi",
- "windows-targets",
 ]
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -411,15 +411,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -427,14 +427,12 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.42.2"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
+checksum = "ab2d11b2f17a45095b8c3603928ba29d7d918d7129d0d0641a36ba73cf07daa6"
 dependencies = [
  "console",
- "linked-hash-map",
  "once_cell",
- "pin-project",
  "regex",
  "similar",
 ]
@@ -454,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -480,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
@@ -542,16 +540,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -668,15 +660,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "paste"
@@ -711,26 +703,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "portable-atomic-util"
@@ -802,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -831,12 +803,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rawpointer"
@@ -901,9 +879,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.0.0"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8dcd64f141950290e45c99f7710ede1b600297c91818bb30b3667c0f45dc0"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
@@ -914,15 +892,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safe_arch"
@@ -1041,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1142,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "900f6c86a685850b1bc9f6223b20125115ee3f31e01207d81655bbcc0aea9231"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1154,37 +1132,44 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
+name = "toml_write"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "28391a4201ba7eb1984cfeb6862c0b3ea2cfe23332298967c749dddc0d6cd976"
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "utf8parse"
@@ -1213,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -1382,18 +1367,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]

--- a/crates/intder/src/lib.rs
+++ b/crates/intder/src/lib.rs
@@ -1350,7 +1350,7 @@ impl Intder {
         let f2 = f2.as_slice();
         let pairs = [(f2, "fort.15"), (f3, "fort.30"), (f4, "fort.40")];
         for (fcs, file) in pairs {
-            let filename = format!("{dir}/{}", file);
+            let filename = format!("{dir}/{file}");
             let mut f = match File::create(&filename) {
                 Ok(f) => f,
                 Err(e) => panic!("failed to create `{filename}` for `{e}`"),

--- a/crates/pbqff/src/coord_type/findiff.rs
+++ b/crates/pbqff/src/coord_type/findiff.rs
@@ -204,7 +204,7 @@ pub trait FiniteDifference {
         } in targets
         {
             if DEBUG == "fcs" {
-                eprintln!("source index: {}", source_index);
+                eprintln!("source index: {source_index}");
             }
             let energy = energies[source_index];
             for idx in &indices {
@@ -342,13 +342,13 @@ pub trait FiniteDifference {
         } else {
             vec![
                 proto!(self, names, coords, step_size, 1. * scale, i, j, k),
-                proto!(self, names, coords, step_size, -1. * scale, i, -j, k),
-                proto!(self, names, coords, step_size, -1. * scale, -i, j, k),
+                proto!(self, names, coords, step_size, -scale, i, -j, k),
+                proto!(self, names, coords, step_size, -scale, -i, j, k),
                 proto!(self, names, coords, step_size, 1. * scale, -i, -j, k),
-                proto!(self, names, coords, step_size, -1. * scale, i, j, -k),
+                proto!(self, names, coords, step_size, -scale, i, j, -k),
                 proto!(self, names, coords, step_size, 1. * scale, i, -j, -k),
                 proto!(self, names, coords, step_size, 1. * scale, -i, j, -k),
-                proto!(self, names, coords, step_size, -1. * scale, -i, -j, -k),
+                proto!(self, names, coords, step_size, -scale, -i, -j, -k),
             ]
         }
     }
@@ -372,8 +372,8 @@ pub trait FiniteDifference {
                 proto!(self, names, coords, step, 1. * scale, i, i, i, l),
                 proto!(self, names, coords, step, -3. * scale, i, l),
                 proto!(self, names, coords, step, 3. * scale, -i, l),
-                proto!(self, names, coords, step, -1. * scale, -i, -i, -i, l),
-                proto!(self, names, coords, step, -1. * scale, i, i, i, -l),
+                proto!(self, names, coords, step, -scale, -i, -i, -i, l),
+                proto!(self, names, coords, step, -scale, i, i, i, -l),
                 proto!(self, names, coords, step, 3. * scale, i, -l),
                 proto!(self, names, coords, step, -3. * scale, -i, -l),
                 proto!(self, names, coords, step, 1. * scale, -i, -i, -i, -l),
@@ -399,12 +399,12 @@ pub trait FiniteDifference {
                 proto!(self, names, coords, step, 1. * scale, i, i, k, l),
                 proto!(self, names, coords, step, -2. * scale, k, l),
                 proto!(self, names, coords, step, 1. * scale, -i, -i, k, l),
-                proto!(self, names, coords, step, -1. * scale, i, i, -k, l),
+                proto!(self, names, coords, step, -scale, i, i, -k, l),
                 proto!(self, names, coords, step, 2. * scale, -k, l),
-                proto!(self, names, coords, step, -1. * scale, -i, -i, -k, l),
-                proto!(self, names, coords, step, -1. * scale, i, i, k, -l),
+                proto!(self, names, coords, step, -scale, -i, -i, -k, l),
+                proto!(self, names, coords, step, -scale, i, i, k, -l),
                 proto!(self, names, coords, step, 2. * scale, k, -l),
-                proto!(self, names, coords, step, -1. * scale, -i, -i, k, -l),
+                proto!(self, names, coords, step, -scale, -i, -i, k, -l),
                 proto!(self, names, coords, step, 1. * scale, i, i, -k, -l),
                 proto!(self, names, coords, step, -2. * scale, -k, -l),
                 proto!(self, names, coords, step, 1. * scale, -i, -i, -k, -l),
@@ -451,20 +451,20 @@ pub trait FiniteDifference {
         } else {
             vec![
                 proto!(self, names, coords, step, 1. * scale, i, j, k, l),
-                proto!(self, names, coords, step, -1. * scale, i, -j, k, l),
-                proto!(self, names, coords, step, -1. * scale, -i, j, k, l),
+                proto!(self, names, coords, step, -scale, i, -j, k, l),
+                proto!(self, names, coords, step, -scale, -i, j, k, l),
                 proto!(self, names, coords, step, 1. * scale, -i, -j, k, l),
-                proto!(self, names, coords, step, -1. * scale, i, j, -k, l),
+                proto!(self, names, coords, step, -scale, i, j, -k, l),
                 proto!(self, names, coords, step, 1. * scale, i, -j, -k, l),
                 proto!(self, names, coords, step, 1. * scale, -i, j, -k, l),
-                proto!(self, names, coords, step, -1. * scale, -i, -j, -k, l),
-                proto!(self, names, coords, step, -1. * scale, i, j, k, -l),
+                proto!(self, names, coords, step, -scale, -i, -j, -k, l),
+                proto!(self, names, coords, step, -scale, i, j, k, -l),
                 proto!(self, names, coords, step, 1. * scale, i, -j, k, -l),
                 proto!(self, names, coords, step, 1. * scale, -i, j, k, -l),
-                proto!(self, names, coords, step, -1. * scale, -i, -j, k, -l),
+                proto!(self, names, coords, step, -scale, -i, -j, k, -l),
                 proto!(self, names, coords, step, 1. * scale, i, j, -k, -l),
-                proto!(self, names, coords, step, -1. * scale, i, -j, -k, -l),
-                proto!(self, names, coords, step, -1. * scale, -i, j, -k, -l),
+                proto!(self, names, coords, step, -scale, i, -j, -k, -l),
+                proto!(self, names, coords, step, -scale, -i, j, -k, -l),
                 proto!(self, names, coords, step, 1. * scale, -i, -j, -k, -l),
             ]
         }

--- a/crates/pbqff/src/main.rs
+++ b/crates/pbqff/src/main.rs
@@ -64,7 +64,7 @@ fn main() -> Result<(), std::io::Error> {
     if args.json {
         let config = Config::load(&args.infile);
         match serde_json::to_string(&config) {
-            Ok(s) => println!("{}", s),
+            Ok(s) => println!("{s}"),
             Err(e) => {
                 die!("failed to deserialize {} with {e}", args.infile);
             }

--- a/crates/spectro/src/lib.rs
+++ b/crates/spectro/src/lib.rs
@@ -568,7 +568,7 @@ impl Spectro {
                             FRAC_PI_2
                         } else if iz2y == 0 {
                             f64::atan(
-                                -1.0 * lxm[(ncomp2, imode1)]
+                                -lxm[(ncomp2, imode1)]
                                     / lxm[(ncomp1, imode2)],
                             )
                         } else {
@@ -581,7 +581,7 @@ impl Spectro {
                         let ncomp3 = ncomp1 + 2;
                         if lxm[(ncomp3, imode2)].abs() > TOLER {
                             f64::atan(
-                                -1.0 * lxm[(ncomp3, imode1)]
+                                -lxm[(ncomp3, imode1)]
                                     / lxm[(ncomp3, imode2)],
                             )
                         } else if lxm[(ncomp3, imode1)].abs() > TOLER {
@@ -696,8 +696,7 @@ impl Spectro {
 
                                 test -= f64::cos(alpha * s)
                                     * lxm[(ncomp23, imode2)];
-                                let test2 = -1.0
-                                    * lxm[(ncomp23, imode1)]
+                                let test2 = -lxm[(ncomp23, imode1)]
                                     * f64::sin(-alpha * s);
                                 let test3 = (test.abs() - test2.abs())
                                     / lxm[(ncomp3, imode2)];

--- a/crates/spectro/src/lib.rs
+++ b/crates/spectro/src/lib.rs
@@ -568,8 +568,7 @@ impl Spectro {
                             FRAC_PI_2
                         } else if iz2y == 0 {
                             f64::atan(
-                                -lxm[(ncomp2, imode1)]
-                                    / lxm[(ncomp1, imode2)],
+                                -lxm[(ncomp2, imode1)] / lxm[(ncomp1, imode2)],
                             )
                         } else {
                             FRAC_PI_2
@@ -581,8 +580,7 @@ impl Spectro {
                         let ncomp3 = ncomp1 + 2;
                         if lxm[(ncomp3, imode2)].abs() > TOLER {
                             f64::atan(
-                                -lxm[(ncomp3, imode1)]
-                                    / lxm[(ncomp3, imode2)],
+                                -lxm[(ncomp3, imode1)] / lxm[(ncomp3, imode2)],
                             )
                         } else if lxm[(ncomp3, imode1)].abs() > TOLER {
                             FRAC_PI_2

--- a/crates/spectro/src/output.rs
+++ b/crates/spectro/src/output.rs
@@ -80,7 +80,7 @@ impl Display for Output {
                     icombn: _,
                 },
         } = self;
-        writeln!(f, "Geometry: {:.8}", geom)?;
+        writeln!(f, "Geometry: {geom:.8}")?;
         writeln!(
             f,
             "Vibrational Frequencies (cm-1):\n{:>5}{:>8}{:>8}{:>8}{:>8}",
@@ -120,9 +120,9 @@ impl Display for Output {
             }
         }
 
-        writeln!(f, "\nQuartic Distortion Constants (cm-1):\n{}", quartic)?;
+        writeln!(f, "\nQuartic Distortion Constants (cm-1):\n{quartic}")?;
 
-        writeln!(f, "Sextic Distortion Constants (cm-1):\n{}", sextic)?;
+        writeln!(f, "Sextic Distortion Constants (cm-1):\n{sextic}")?;
 
         writeln!(f, "\nCoriolis Resonances:")?;
         for Coriolis { i, j, axis } in coriolis {

--- a/crates/spectro/src/polyads.rs
+++ b/crates/spectro/src/polyads.rs
@@ -99,12 +99,12 @@ pub(crate) fn resona(
 
     // construct the resonance matrix, then call symm_eigen_decomp to get the
     // eigenvalues and eigenvectors
-    println!("\nResonance matrix:{:.3}", resmat);
+    println!("\nResonance matrix:{resmat:.3}");
 
     let (vals, vecs) = symm_eigen_decomp(resmat.clone(), false);
 
     println!("Eigenvalues:{:.2}", vals.transpose());
-    println!("Eigenvectors:{:.7}", vecs);
+    println!("Eigenvectors:{vecs:.7}");
 
     Some(resmat)
 }

--- a/crates/spectro/src/utils.rs
+++ b/crates/spectro/src/utils.rs
@@ -136,7 +136,7 @@ pub fn to_wavenumbers(freqs: &Dvec) -> Dvec {
         freqs.len(),
         freqs.iter().map(|f| {
             if *f < 0.0 {
-                -1.0 * WAVE * f64::sqrt(-f)
+                -WAVE * f64::sqrt(-f)
             } else {
                 WAVE * f64::sqrt(*f)
             }

--- a/crates/taylor-bin/src/main.rs
+++ b/crates/taylor-bin/src/main.rs
@@ -93,8 +93,8 @@ fn main() -> std::io::Result<()> {
         pg
     };
 
-    println!("Normalized Geometry:\n{:20.12}", mol);
-    println!("Point Group = {}", pg);
+    println!("Normalized Geometry:\n{mol:20.12}");
+    println!("Point Group = {pg}");
 
     let nsic = intder.symmetry_internals.len();
     // generate a displacement for each SIC
@@ -202,7 +202,7 @@ fn main() -> std::io::Result<()> {
                                 intder.atoms[*d].label,
                                 d + 1
                             ),
-			    _ => panic!("tell brent to support {}", l),
+			    _ => panic!("tell brent to support {l}"),
                             // intder::Siic::Lin1(_, _, _, _) => todo!(),
                             // intder::Siic::Out(_, _, _, _) => todo!(),
                         }
@@ -228,7 +228,7 @@ fn main() -> std::io::Result<()> {
 
         let mut f = std::fs::File::create("intder.in")?;
         use std::io::Write;
-        writeln!(f, "{}", intder)?;
+        writeln!(f, "{intder}")?;
 
         let anpass = taylor.to_anpass(
             &taylor_disps,
@@ -236,7 +236,7 @@ fn main() -> std::io::Result<()> {
             cfg.step_size,
         );
         let mut f = std::fs::File::create("anpass.in")?;
-        writeln!(f, "{}", anpass)?;
+        writeln!(f, "{anpass}")?;
     }
 
     Ok(())


### PR DESCRIPTION
This is a hopeful fix for the dependabot issues. I ran `cargo clippy --fix` and then `cargo fmt` to fix a failed `fmt` check.