### PR TITLE
Fix unused code

### DIFF
--- a/crates/spectro/src/state.rs
+++ b/crates/spectro/src/state.rs
@@ -83,6 +83,7 @@ impl State {
 }
 
 // this is actually awful but it works
+#[allow(unused)]
 pub struct I1states(pub Vec<Vec<usize>>);
 
 impl Display for I1states {
@@ -95,6 +96,7 @@ impl Display for I1states {
 }
 
 // this is actually awful but it works
+#[allow(unused)]
 pub struct I2states(pub Vec<Vec<(usize, usize)>>);
 
 impl Display for I2states {


### PR DESCRIPTION
I tried using `expect(unused)` here, but it didn't work for some reason. `allow` is fine for now. It looks like these are only used for pretty printing in a single test, so there's probably a better fix here (moving them to that test's module or just inlining the printing logic), but this will work for now.