### PR TITLE
Trim down CI config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
       - name: install rustfmt
         run: rustup component add rustfmt
       - name: cargo fmt --check --all
@@ -30,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
       - name: "Install Rust toolchain"
         run: rustup component add clippy
       - name: cargo clippy
@@ -41,6 +43,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
       - name: cargo doc
         run: cargo doc --no-deps --all-features
         env:
@@ -59,5 +62,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
       - name: make install.full
         run: make install.full PREFIX=${{ matrix.prefix }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
       run: rustup target add ${{ matrix.target }}
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Build
       run: cargo build --release --features vers --target ${{ matrix.target }}
     - name: Package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
 
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''


### PR DESCRIPTION
Summary
--

This PR simplifies the CI workflows a bit, relying on the pre-installed rustup
instead of the `rust-toolchain` action and the `clippy-check` action.

I also ran zizmor for the first time and applied its autofixes. There's still an issue in the release workflow that I will try to fix, possibly by migrating to cargo-dist, and we should also run it in CI, but this is a good start.

Test Plan
--

CI on this PR
